### PR TITLE
Upgraded equatable library from 0.2.5 to 1.0.1

### DIFF
--- a/lib/src/models/json_api.dart
+++ b/lib/src/models/json_api.dart
@@ -96,6 +96,9 @@ class JsonApiModel with EquatableMixin implements Model {
 
   static String toUtcIsoString(DateTime value) =>
       value.toUtc().toIso8601String();
+
+  @override
+  List<Object> get props => [id, type, errors];
 }
 
 abstract class JsonApiManyModel<T extends JsonApiModel> extends Iterable<T> {

--- a/lib/src/models/json_api.dart
+++ b/lib/src/models/json_api.dart
@@ -3,7 +3,7 @@ import 'package:equatable/equatable.dart';
 import '../interfaces.dart';
 import '../serializers/json_api.dart';
 
-class JsonApiModel with EquatableMixinBase, EquatableMixin implements Model {
+class JsonApiModel with EquatableMixin implements Model {
   JsonApiDocument jsonApiDoc;
 
   JsonApiModel(this.jsonApiDoc);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
   sdk: ">=2.1.0 <3.0.0"
 
 dependencies:
-  equatable: ^0.2.5
+  equatable: ^1.0.1
   http: ^0.12.0+2
 
 dev_dependencies:


### PR DESCRIPTION
Upgraded `equatable` library from `0.2.5` to `1.0.1`

- removed deprecated `EquatableMixinBase` mixin from `JsonApiModel` class
- added override props for id, type and errors fields to `JsonApiModel` class