### PR TITLE
JSON:API adapter: error methods refactoring

### DIFF
--- a/lib/src/models/json_api.dart
+++ b/lib/src/models/json_api.dart
@@ -28,7 +28,7 @@ class JsonApiModel with EquatableMixin implements Model {
   Map<String, dynamic> get attributes => jsonApiDoc.attributes;
   Map<String, dynamic> get relationships => jsonApiDoc.relationships;
   Iterable<dynamic> get included => jsonApiDoc.included;
-  Iterable<dynamic> get errors => jsonApiDoc.errors;
+  List<Map<String, dynamic>> get errors => jsonApiDoc.errors;
 
   @override
   String get id => jsonApiDoc.id;

--- a/lib/src/models/json_api.dart
+++ b/lib/src/models/json_api.dart
@@ -29,7 +29,6 @@ class JsonApiModel with EquatableMixin implements Model {
   Map<String, dynamic> get relationships => jsonApiDoc.relationships;
   Iterable<dynamic> get included => jsonApiDoc.included;
   Iterable<dynamic> get errors => jsonApiDoc.errors;
-  set errors(Iterable<dynamic> value) => jsonApiDoc.errors = value;
 
   @override
   String get id => jsonApiDoc.id;
@@ -39,7 +38,7 @@ class JsonApiModel with EquatableMixin implements Model {
 
   bool get isNew => jsonApiDoc.isNew;
 
-  bool get hasErrors => errors != null ? errors.isNotEmpty : false;
+  bool get hasErrors => jsonApiDoc.hasErrors;
 
   @override
   String serialize() => JsonApiSerializer().serialize(jsonApiDoc);
@@ -54,32 +53,19 @@ class JsonApiModel with EquatableMixin implements Model {
   Iterable<JsonApiDocument> includedDocs(String type, [Iterable<String> ids]) =>
       jsonApiDoc.includedDocs(type, ids);
 
-  bool attributeHasErrors(String attributeName) => hasErrors
-      ? errors.any((error) =>
-          _isAttributeError(error, attributeName) && _hasErrorDetail(error))
-      : false;
+  bool attributeHasErrors(String attributeName) =>
+      jsonApiDoc.attributeHasErrors(attributeName);
 
-  Iterable<String> errorsFor(String attributeName) => errors
-      .where((error) => _isAttributeError(error, attributeName))
-      .map((error) => error['detail']);
+  Iterable<String> errorsFor(String attributeName) =>
+      jsonApiDoc.errorsFor(attributeName);
 
   void clearErrorsFor(String attributeName) {
-    errors = errors
-        .where((error) => !_isAttributeError(error, attributeName))
-        .toList();
+    jsonApiDoc.clearErrorsFor(attributeName);
   }
 
   void clearErrors() {
-    jsonApiDoc.errors = null;
+    jsonApiDoc.clearErrors();
   }
-
-  bool _isAttributeError(Map<String, dynamic> error, String attributeName) =>
-      error['source']['pointer'] == "/data/attributes/$attributeName";
-
-  bool _hasErrorDetail(Map<String, dynamic> error) =>
-      error['detail'] != null &&
-      error['detail'] is String &&
-      (error['detail'] as String).isNotEmpty;
 
   void setHasOne(String relationshipName, JsonApiModel model) {
     jsonApiDoc.setHasOne(relationshipName, model.id, model.type);

--- a/lib/src/models/json_api.dart
+++ b/lib/src/models/json_api.dart
@@ -67,6 +67,10 @@ class JsonApiModel with EquatableMixin implements Model {
     jsonApiDoc.clearErrors();
   }
 
+  void addErrorFor(String attributeName, String errorMessage) {
+    jsonApiDoc.addErrorFor(attributeName, errorMessage);
+  }
+
   void setHasOne(String relationshipName, JsonApiModel model) {
     jsonApiDoc.setHasOne(relationshipName, model.id, model.type);
   }

--- a/lib/src/models/json_api.dart
+++ b/lib/src/models/json_api.dart
@@ -82,13 +82,7 @@ class JsonApiModel with EquatableMixin implements Model {
       (error['detail'] as String).isNotEmpty;
 
   void setHasOne(String relationshipName, JsonApiModel model) {
-    if (relationships.containsKey(relationshipName)) {
-      relationships[relationshipName]['data']['id'] = model.id;
-    } else {
-      relationships[relationshipName] = {
-        'data': {'id': model.id, 'type': model.type}
-      };
-    }
+    jsonApiDoc.setHasOne(relationshipName, model.id, model.type);
   }
 
   static DateTime toDateTime(String value) =>

--- a/lib/src/serializers/json_api.dart
+++ b/lib/src/serializers/json_api.dart
@@ -136,7 +136,11 @@ class JsonApiDocument {
   }
 
   void addErrorFor(String attributeName, String errorMessage) {
-    // TODO
+    errors ??= List<Map<String, dynamic>>();
+    errors.add({
+      'source': {'pointer': "/data/attributes/$attributeName"},
+      'detail': errorMessage,
+    });
   }
 
   bool _isAttributeError(Map<String, dynamic> error, String attributeName) =>

--- a/lib/src/serializers/json_api.dart
+++ b/lib/src/serializers/json_api.dart
@@ -96,6 +96,16 @@ class JsonApiDocument {
           ? dataForHasMany(relationshipName).map((record) => record['id'])
           : List<String>();
 
+  void setHasOne(String relationshipName, String modelId, String modelType) {
+    if (relationships.containsKey(relationshipName)) {
+      relationships[relationshipName]['data']['id'] = modelId;
+    } else {
+      relationships[relationshipName] = {
+        'data': {'id': modelId, 'type': modelType}
+      };
+    }
+  }
+
   Iterable<JsonApiDocument> includedDocs(String type, [Iterable<String> ids]) {
     ids ??= idsFor(type);
     return (included ?? List())

--- a/lib/src/serializers/json_api.dart
+++ b/lib/src/serializers/json_api.dart
@@ -77,6 +77,8 @@ class JsonApiDocument {
 
   bool get isNew => id == null;
 
+  bool get hasErrors => errors != null ? errors.isNotEmpty : false;
+
   Map<String, dynamic> dataForHasOne(String relationshipName) =>
       relationships.containsKey(relationshipName)
           ? (relationships[relationshipName]['data'] ?? Map<String, dynamic>())
@@ -113,6 +115,37 @@ class JsonApiDocument {
         .map<JsonApiDocument>((record) => JsonApiDocument(record['id'],
             record['type'], record['attributes'], record['relationships']));
   }
+
+  bool attributeHasErrors(String attributeName) => hasErrors
+      ? errors.any((error) =>
+          _isAttributeError(error, attributeName) && _hasErrorDetail(error))
+      : false;
+
+  Iterable<String> errorsFor(String attributeName) => errors
+      .where((error) => _isAttributeError(error, attributeName))
+      .map((error) => error['detail']);
+
+  void clearErrorsFor(String attributeName) {
+    errors = errors
+        .where((error) => !_isAttributeError(error, attributeName))
+        .toList();
+  }
+
+  void clearErrors() {
+    errors = null;
+  }
+
+  void addErrorFor(String attributeName, String errorMessage) {
+    // TODO
+  }
+
+  bool _isAttributeError(Map<String, dynamic> error, String attributeName) =>
+      error['source']['pointer'] == "/data/attributes/$attributeName";
+
+  bool _hasErrorDetail(Map<String, dynamic> error) =>
+      error['detail'] != null &&
+      error['detail'] is String &&
+      (error['detail'] as String).isNotEmpty;
 }
 
 class JsonApiManyDocument extends Iterable<JsonApiDocument> {

--- a/lib/src/serializers/json_api.dart
+++ b/lib/src/serializers/json_api.dart
@@ -57,7 +57,7 @@ class JsonApiDocument {
   Map<String, dynamic> attributes;
   Map<String, dynamic> relationships;
   Iterable<dynamic> included;
-  Iterable<dynamic> errors;
+  List<Map<String, dynamic>> errors;
 
   JsonApiDocument(this.id, this.type, this.attributes, this.relationships,
       [this.included]);


### PR DESCRIPTION
Define them in Document because they hold knowledge of JSON:API format, then make them available in Model for easier usage by the callers.