### PR TITLE
Fix bug on JsonApiAdapter's findMany() method

### DIFF
--- a/lib/src/adapters/json_api.dart
+++ b/lib/src/adapters/json_api.dart
@@ -16,7 +16,9 @@ class JsonApiAdapter extends Adapter with Http {
   @override
   Future<JsonApiDocument> find(String endpoint, String id,
       {bool forceReload = false}) async {
-    if (forceReload == true) return fetchAndCache(endpoint, id);
+    if (forceReload == true) {
+      return fetchAndCache(endpoint, id);
+    }
     JsonApiDocument cached = peek(endpoint, id);
     if (cached != null) {
       return cached;
@@ -191,7 +193,9 @@ class JsonApiAdapter extends Adapter with Http {
   @override
   void clearCache() {
     _cache.values.forEach((docCache) {
-      if (docCache is Map) docCache.clear();
+      if (docCache is Map) {
+        docCache.clear();
+      }
     });
     _cache.clear();
   }

--- a/lib/src/adapters/json_api.dart
+++ b/lib/src/adapters/json_api.dart
@@ -40,7 +40,12 @@ class JsonApiAdapter extends Adapter with Http {
   @override
   Future<JsonApiManyDocument> findMany(String endpoint, Iterable<String> ids,
       {bool forceReload = false}) async {
-    if (forceReload == true) return await query(endpoint, _idsParam(ids));
+    if (ids.isEmpty) {
+      return Future.value(JsonApiManyDocument(List<JsonApiDocument>()));
+    }
+    if (forceReload == true) {
+      return await query(endpoint, _idsParam(ids));
+    }
     JsonApiManyDocument cached = peekMany(endpoint, ids);
     if (cached.length != ids.length) {
       List<JsonApiDocument> cachedDocs = cached.toList();

--- a/lib/src/serializers/json_api.dart
+++ b/lib/src/serializers/json_api.dart
@@ -81,7 +81,9 @@ class JsonApiDocument {
   static _deepCopyRelationships(other) {
     var firstValue;
     if (other is Map) {
-      if (other.isEmpty) return Map<String, dynamic>();
+      if (other.isEmpty) {
+        return Map<String, dynamic>();
+      }
       firstValue = other.values.first;
       if (firstValue is! Map && firstValue is! List) {
         return Map<String, dynamic>.from(other);
@@ -93,7 +95,9 @@ class JsonApiDocument {
       }
     }
     if (other is List) {
-      if (other.isEmpty) return List<Map<String, dynamic>>();
+      if (other.isEmpty) {
+        return List<Map<String, dynamic>>();
+      }
       firstValue = other.first;
       if (firstValue is! Map && firstValue is! List) {
         return List<Map<String, dynamic>>.from(other);


### PR DESCRIPTION
`JsonApiAdapter`'s `findMany()` method was sending an http request even when the `ids` argument was an empty collection. With the proposed changes, it returns an empty `List` of `JsonApiDocument` in such a case.