### PR TITLE
Optionally disable SSL, plus small improvements

### DIFF
--- a/lib/src/adapters/json_api.dart
+++ b/lib/src/adapters/json_api.dart
@@ -4,11 +4,16 @@ import '../interfaces.dart';
 import '../serializers/json_api.dart';
 
 class JsonApiAdapter extends Adapter with Http {
-  String apiPath;
+  final String apiPath;
   Map<String, Map<String, JsonApiDocument>> _cache;
 
-  JsonApiAdapter(String hostname, this.apiPath) : super(JsonApiSerializer()) {
+  JsonApiAdapter(
+    String hostname,
+    this.apiPath, {
+    bool useSSL: true,
+  }) : super(JsonApiSerializer()) {
     this.hostname = hostname;
+    this.useSSL = useSSL;
     _cache = Map<String, Map<String, JsonApiDocument>>();
     addHeader('Content-Type', 'application/json; charset=utf-8');
   }

--- a/lib/src/adapters/mixins/http.dart
+++ b/lib/src/adapters/mixins/http.dart
@@ -7,6 +7,7 @@ import '../../exceptions.dart';
 
 mixin Http {
   String hostname;
+  bool useSSL;
   var headers = Map<String, String>();
 
   String checkAndDecode(http.Response response) {
@@ -58,36 +59,49 @@ mixin Http {
     Map<String, String> queryParams,
   }) async {
     return await _safelyRun(() async {
-      var url = Uri.https(hostname, path, queryParams);
-      return await http.get(url, headers: headers);
+      return await http.get(
+        _buildUri(path, queryParams),
+        headers: headers,
+      );
     });
   }
 
   Future<http.Response> httpPost(String path, {String body}) async {
     return await _safelyRun(() async {
-      var url = Uri.https(hostname, path);
-      return await http.post(url, headers: headers, body: body);
+      return await http.post(
+        _buildUri(path),
+        headers: headers,
+        body: body,
+      );
     });
   }
 
   Future<http.Response> httpPatch(String path, {String body}) async {
     return await _safelyRun(() async {
-      var url = Uri.https(hostname, path);
-      return await http.patch(url, headers: headers, body: body);
+      return await http.patch(
+        _buildUri(path),
+        headers: headers,
+        body: body,
+      );
     });
   }
 
   Future<http.Response> httpPut(String path, {String body}) async {
     return await _safelyRun(() async {
-      var url = Uri.https(hostname, path);
-      return await http.put(url, headers: headers, body: body);
+      return await http.put(
+        _buildUri(path),
+        headers: headers,
+        body: body,
+      );
     });
   }
 
   Future<http.Response> httpDelete(String path) async {
     return await _safelyRun(() async {
-      var url = Uri.https(hostname, path);
-      return await http.delete(url, headers: headers);
+      return await http.delete(
+        _buildUri(path),
+        headers: headers,
+      );
     });
   }
 
@@ -102,4 +116,8 @@ mixin Http {
       throw NetworkError();
     }
   }
+
+  Uri _buildUri(String path, [Map<String, String> queryParams]) => useSSL
+      ? Uri.https(hostname, path, queryParams)
+      : Uri.http(hostname, path, queryParams);
 }

--- a/lib/src/models/json_api.dart
+++ b/lib/src/models/json_api.dart
@@ -76,6 +76,10 @@ class JsonApiModel with EquatableMixin implements Model {
     jsonApiDoc.setHasOne(relationshipName, model.id, model.type);
   }
 
+  void clearHasOne(String relationshipName) {
+    jsonApiDoc.clearHasOne(relationshipName);
+  }
+
   static DateTime toDateTime(String value) =>
       (value == null || value.isEmpty) ? null : DateTime.parse(value).toLocal();
 

--- a/lib/src/serializers/json_api.dart
+++ b/lib/src/serializers/json_api.dart
@@ -146,6 +146,14 @@ class JsonApiDocument {
     }
   }
 
+  void clearHasOne(String relationshipName) {
+    if (relationships.containsKey(relationshipName)) {
+      relationships[relationshipName]['data'] = null;
+    } else {
+      relationships[relationshipName] = {'data': null};
+    }
+  }
+
   Iterable<JsonApiDocument> includedDocs(String type, [Iterable<String> ids]) {
     ids ??= idsFor(type);
     return (included ?? [])

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,6 @@
 name: rest_data
 description: Easily interact with REST APIs without dealing with HTTP and JSON
 version: 0.3.4
-author: Algonauti <devel@algonauti.com>
 homepage: https://www.algonauti.com
 
 environment:


### PR DESCRIPTION
- Let `JsonApiAdapter` accept an optional `useSSL` boolean argument (default: `true`). Useful to set it to `false` when referencing a local development backend
- Add to `JsonApiModel` a method to clear has-one relationship: `clearHasOne()`
- `pubspec.yml`: remove author field, now deprecated