### PR TITLE
Transform relationships to non-null in constructor

### DIFF
--- a/lib/src/serializers/json_api.dart
+++ b/lib/src/serializers/json_api.dart
@@ -62,9 +62,11 @@ class JsonApiDocument {
   Iterable<dynamic> included;
   List<dynamic> errors;
 
-  JsonApiDocument(this.id, this.type, this.attributes, this.relationships,
+  JsonApiDocument(
+      this.id, this.type, this.attributes, Map<String, dynamic>? relationships,
       [Iterable<dynamic>? included = null])
       : errors = [],
+        this.relationships = relationships ?? {},
         this.included = included ?? [];
 
   JsonApiDocument.create(this.type, this.attributes,


### PR DESCRIPTION
@algodave fyi

An issue spotted while working on an example app. Relationships can be null if accessing them directly in json, so made non-null conversion in constructor 