### PR TITLE
fix: fetching included one-one relationships

### DIFF
--- a/lib/src/models/json_api.dart
+++ b/lib/src/models/json_api.dart
@@ -63,6 +63,9 @@ class JsonApiModel with EquatableMixin implements Model {
           [Iterable<String>? ids]) =>
       jsonApiDoc.includedDocs(type, ids);
 
+  JsonApiDocument? includedDoc(String type) =>
+      jsonApiDoc.includedDoc(type);
+
   bool attributeHasErrors(String attributeName) =>
       jsonApiDoc.attributeHasErrors(attributeName);
 

--- a/lib/src/serializers/json_api.dart
+++ b/lib/src/serializers/json_api.dart
@@ -206,6 +206,16 @@ class JsonApiDocument {
             record['type'], record['attributes'], record['relationships']));
   }
 
+  JsonApiDocument? includedDoc(String type) {
+    var id = idFor(type);
+    var it = included
+        .where((record) => record['type'] == type && record['id'] == id)
+        .map<JsonApiDocument>((record) => JsonApiDocument(record['id'],
+        record['type'], record['attributes'], record['relationships']));
+
+    return it.isNotEmpty ? it.first : null;
+  }
+
   bool attributeHasErrors(String attributeName) => hasErrors
       ? errors.any((error) =>
           _isAttributeError(error, attributeName) && _hasErrorDetail(error))


### PR DESCRIPTION
Fixes issue #24. A new method is added called `includedDoc` to the JsonApiModel, which doesn't expect an array of relationships.