### PR TITLE
Wrapper method includedIdsFor(relationshipName, modelType) added.

### DIFF
--- a/lib/src/models/json_api.dart
+++ b/lib/src/models/json_api.dart
@@ -63,12 +63,11 @@ class JsonApiModel with EquatableMixin implements Model {
           [Iterable<String>? ids]) =>
       jsonApiDoc.includedDocs(type, ids);
 
-  JsonApiDocument? includedDoc(String type) =>
-      jsonApiDoc.includedDoc(type);
+  JsonApiDocument? includedDoc(String type) => jsonApiDoc.includedDoc(type);
 
-  Iterable<String> includedIdsFor(String relationshipName, String modelType) => 
+  Iterable<String> includedIdsFor(String relationshipName, String modelType) =>
       jsonApiDoc.includedIdsFor(relationshipName, modelType);
-  
+
   bool attributeHasErrors(String attributeName) =>
       jsonApiDoc.attributeHasErrors(attributeName);
 
@@ -131,6 +130,6 @@ abstract class JsonApiManyModel<T extends JsonApiModel> extends Iterable<T> {
   Iterable<JsonApiDocument> includedDocs(String type) =>
       manyDoc.includedDocs(type);
 
-  Iterable<String> includedIdsFor(String relationshipName, String modelType) => 
+  Iterable<String> includedIdsFor(String relationshipName, String modelType) =>
       manyDoc.includedIdsFor(relationshipName, modelType);
 }

--- a/lib/src/models/json_api.dart
+++ b/lib/src/models/json_api.dart
@@ -66,6 +66,9 @@ class JsonApiModel with EquatableMixin implements Model {
   JsonApiDocument? includedDoc(String type) =>
       jsonApiDoc.includedDoc(type);
 
+  Iterable<String> includedIdsFor(String relationshipName, String modelType) => 
+      jsonApiDoc.includedIdsFor(relationshipName, modelType);
+  
   bool attributeHasErrors(String attributeName) =>
       jsonApiDoc.attributeHasErrors(attributeName);
 
@@ -127,4 +130,7 @@ abstract class JsonApiManyModel<T extends JsonApiModel> extends Iterable<T> {
 
   Iterable<JsonApiDocument> includedDocs(String type) =>
       manyDoc.includedDocs(type);
+
+  Iterable<String> includedIdsFor(String relationshipName, String modelType) => 
+      manyDoc.includedIdsFor(relationshipName, modelType);
 }

--- a/lib/src/serializers/json_api.dart
+++ b/lib/src/serializers/json_api.dart
@@ -223,16 +223,17 @@ class JsonApiDocument {
     var it = included
         .where((record) => record['type'] == type && record['id'] == id)
         .map<JsonApiDocument>((record) => JsonApiDocument(record['id'],
-        record['type'], record['attributes'], record['relationships']));
+            record['type'], record['attributes'], record['relationships']));
 
     return it.isNotEmpty ? it.first : null;
   }
 
-  Iterable<String> includedIdsFor(String relationshipName, String modelType) => includedDocs(relationshipName)
-      .map((jsonApiDoc) => jsonApiDoc.idFor(modelType))
-      .whereNotNull()
-      .toSet();
-  
+  Iterable<String> includedIdsFor(String relationshipName, String modelType) =>
+      includedDocs(relationshipName)
+          .map((jsonApiDoc) => jsonApiDoc.idFor(modelType))
+          .whereNotNull()
+          .toSet();
+
   bool attributeHasErrors(String attributeName) => hasErrors
       ? errors.any((error) =>
           _isAttributeError(error, attributeName) && _hasErrorDetail(error))
@@ -307,9 +308,10 @@ class JsonApiManyDocument extends Iterable<JsonApiDocument> {
       .where((record) => record['type'] == type)
       .map((record) => JsonApiDocument(record['id'], record['type'],
           record['attributes'], record['relationships']));
-  
-  Iterable<String> includedIdsFor(String relationshipName, String modelType) => includedDocs(relationshipName)
-      .map((jsonApiDoc) => jsonApiDoc.idFor(modelType))
-      .whereNotNull()
-      .toSet();
+
+  Iterable<String> includedIdsFor(String relationshipName, String modelType) =>
+      includedDocs(relationshipName)
+          .map((jsonApiDoc) => jsonApiDoc.idFor(modelType))
+          .whereNotNull()
+          .toSet();
 }

--- a/lib/src/serializers/json_api.dart
+++ b/lib/src/serializers/json_api.dart
@@ -1,5 +1,7 @@
 import 'dart:convert';
 
+import 'package:collection/collection.dart';
+
 import '../exceptions.dart';
 import '../interfaces.dart';
 
@@ -226,6 +228,11 @@ class JsonApiDocument {
     return it.isNotEmpty ? it.first : null;
   }
 
+  Iterable<String> includedIdsFor(String relationshipName, String modelType) => includedDocs(relationshipName)
+      .map((jsonApiDoc) => jsonApiDoc.idFor(modelType))
+      .whereNotNull()
+      .toSet();
+  
   bool attributeHasErrors(String attributeName) => hasErrors
       ? errors.any((error) =>
           _isAttributeError(error, attributeName) && _hasErrorDetail(error))
@@ -300,4 +307,9 @@ class JsonApiManyDocument extends Iterable<JsonApiDocument> {
       .where((record) => record['type'] == type)
       .map((record) => JsonApiDocument(record['id'], record['type'],
           record['attributes'], record['relationships']));
+  
+  Iterable<String> includedIdsFor(String relationshipName, String modelType) => includedDocs(relationshipName)
+      .map((jsonApiDoc) => jsonApiDoc.idFor(modelType))
+      .whereNotNull()
+      .toSet();
 }


### PR DESCRIPTION
According to issue #20 `includedIdsFor()` wrapper method added to the project. So that, getting all IDs of included JSON:API documents of a given type became more compact.