### PR TITLE
Hotfix: clear cache on findAll() and findMany()

### DIFF
--- a/lib/src/adapters/json_api.dart
+++ b/lib/src/adapters/json_api.dart
@@ -213,6 +213,14 @@ class JsonApiAdapter extends Adapter with Http {
   }
 
   @override
+  void unCacheAll(String endpoint) {
+    Map? docCache = _cache[endpoint];
+    if (docCache != null) {
+      docCache.clear();
+    }
+  }
+
+  @override
   void clearCache() {
     _cache.values.forEach((docCache) {
       docCache.clear();

--- a/lib/src/adapters/json_api.dart
+++ b/lib/src/adapters/json_api.dart
@@ -82,10 +82,8 @@ class JsonApiAdapter extends Adapter with Http {
     String endpoint, {
     Map<String, String> queryParams = const {},
   }) async {
-    final response =
-        await httpGet("$apiPath/$endpoint", queryParams: queryParams);
-    String payload = checkAndDecode(response) ?? '{}';
-    return _deserializeAndCacheMany(payload, endpoint);
+    unCacheAll(endpoint);
+    return query(endpoint, queryParams);
   }
 
   @override

--- a/lib/src/adapters/json_api.dart
+++ b/lib/src/adapters/json_api.dart
@@ -56,6 +56,7 @@ class JsonApiAdapter extends Adapter with Http {
       return Future.value(JsonApiManyDocument(<JsonApiDocument>[]));
     }
     if (forceReload == true || queryParams.isNotEmpty) {
+      unCacheAll(endpoint);
       return await query(endpoint, {...queryParams, ..._idsParam(ids)});
     }
     JsonApiManyDocument cached = peekMany(endpoint, ids);

--- a/lib/src/interfaces.dart
+++ b/lib/src/interfaces.dart
@@ -27,6 +27,7 @@ abstract class Adapter {
 
   void cache(String endpoint, Object document);
   void unCache(String endpoint, Object document);
+  void unCacheAll(String endpoint);
   void clearCache();
   void cacheMany(String endpoint, Iterable<Object> documents);
   Object? peek(String endpoint, String id);


### PR DESCRIPTION
Assume the following sequence:

 1. Client invokes `findAll()`
 2. One of those records is deleted on the server
 3. Client invokes `findAll()`
 4. Client invokes `peekAll()` -> this will return the record deleted on step 2, because it was cached during step 1

Solution:

 - Uncache all documents of the given endpoint when `findAll()` is invoked.
 - Do the same when `findMany()` is invoked with `forceReload: true`