### PR TITLE
Add methods to unset and nullify an attribute

### DIFF
--- a/lib/src/interfaces.dart
+++ b/lib/src/interfaces.dart
@@ -41,4 +41,6 @@ abstract class Model {
   String serialize();
   T getAttribute<T>(String key);
   void setAttribute<T>(String key, T value);
+  void unsetAttribute(String key);
+  void nullifyAttribute(String key);
 }

--- a/lib/src/models/json_api.dart
+++ b/lib/src/models/json_api.dart
@@ -46,6 +46,16 @@ class JsonApiModel with EquatableMixin implements Model {
       jsonApiDoc.setAttribute<T>(key, value);
 
   @override
+  void unsetAttribute(String key) {
+    jsonApiDoc.unsetAttribute(key);
+  }
+
+  @override
+  void nullifyAttribute(String key) {
+    jsonApiDoc.nullifyAttribute(key);
+  }
+
+  @override
   String serialize() => JsonApiSerializer().serialize(jsonApiDoc);
 
   bool get isNew => jsonApiDoc.isNew;

--- a/lib/src/serializers/json_api.dart
+++ b/lib/src/serializers/json_api.dart
@@ -177,6 +177,14 @@ class JsonApiDocument {
     attributes[key] = rawValue;
   }
 
+  void unsetAttribute(String key) {
+    attributes.remove(key);
+  }
+
+  void nullifyAttribute(String key) {
+    attributes[key] = null;
+  }
+
   bool get hasErrors => errors.isNotEmpty;
 
   Map<String, dynamic> dataForHasOne(String relationshipName) =>


### PR DESCRIPTION
We were missing a way to: a) nullify an attribute, and b) completely remove it. This PR adds `unsetAttribute()` and `nullifyAttribute()` methods to the purpose.